### PR TITLE
Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ If you use this code or result in your paper, please cite our work as:
 QuarkAudio is released under the Apache 2.0 license.
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=alibaba/unified-audio&type=date&legend=top-left&title=QuarkAudio)](https://www.star-history.com/#alibaba/unified-audio&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=alibaba/unified-audio&type=date&legend=top-left&title=QuarkAudio)](https://star-history.dera.page/#alibaba/unified-audio&type=date&legend=top-left)


### PR DESCRIPTION
The Star History chart in the README is currently broken because of GitHub stargazer API restrictions. This change updates the chart link to the working star-history mirror so the chart renders correctly again. The badge, if any, is left untouched.